### PR TITLE
Bugfix openbci_gui_fftplot uVrms

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For more info see https://openbci.com
 
 * Cyton, CytonDaisy, Ganglion - use these SuperCollider classes if you connect to your board via bluetooth serial (the dongle). Maximum sample rate is 250Hz (Cyton) and 200Hz (Ganglion).
 
-* CytonWifi, CytonDaisyWifi, GanglionWifi - these SuperCollider classes require the [WiFi Shield](https://docs.openbci.com/docs/05ThirdParty/03-WiFiShield/WiFiLanding) (also [DIY](https://www.fredrikolofsson.com/f0blog/?q=node/664)) and a special firmware ( [Arduino sketch](https://github.com/redFrik/OpenBCI_WIFI/blob/OpenSoundControl/examples/WifiShieldOSC/WifiShieldOSC.ino) ) for sending OSC. Maximum sample rate for these classes is 16000Hz.
+* CytonWifi, CytonDaisyWifi, GanglionWifi - these SuperCollider classes require the [WiFi Shield](https://docs.openbci.com/docs/05ThirdParty/03-WiFiShield/WiFiLanding) (also [DIY](https://fredrikolofsson.com/f0blog/openbci-wifi-shield-diy/)) and a special firmware ( [Arduino sketch](https://github.com/redFrik/OpenBCI_WIFI/blob/OpenSoundControl/examples/WifiShieldOSC/WifiShieldOSC.ino) ) for sending OSC. Maximum sample rate for these classes is 16000Hz.
 
 * PlaybackData - is a class tha can play back recorded data from file (e.g. the files recorded onto the onboard SD-card).
 

--- a/examples/openbci_gui_fftplot.scd
+++ b/examples/openbci_gui_fftplot.scd
@@ -118,7 +118,9 @@ usr.drawFunc= {
 			if(btn2.value>0, {
 				data= bandpassFilter.filter(data);
 			});
-			c.uVrms= pow(data, 2).mean.sqrt;
+			c.uVrms= 0;
+			data.size.div(2).do{|i| c.uVrms= c.uVrms+pow(data[data.size-1-i], 2)};
+			c.uVrms= (c.uVrms/data.size.div(2)).sqrt;
 			data= fft.fft(data);
 			if(pop4.value>0, {
 				data= smoothFilters[i].filter(data);


### PR DESCRIPTION
uVrms calculations gave the wrong result. Probably safe to fix as they were not visible in the GUI and kind of a hidden feature anyways.