### PR TITLE
bugfix playback data

### DIFF
--- a/DataFilter.sc
+++ b/DataFilter.sc
@@ -15,7 +15,7 @@ DataFilter {
 			"type % not supported. only: %".format(type, this.class.constants.keys.asArray).warn;
 			type= this.class.constants.keys.asArray[0];
 		});
-		this.sampleRate_(argSampleRate?250);  //set a default
+		this.sampleRate_(argSampleRate.asInteger?250);  //set a default
 		this.bufferSize_(argBufferSize?1250);
 	}
 	bufferSize_ {|val|

--- a/OpenBCI-SuperCollider.quark
+++ b/OpenBCI-SuperCollider.quark
@@ -1,7 +1,7 @@
 (
 	\name: 				"OpenBCI",
 	\summary:			"communicating with OpenBCI",
-	\version:			"1.91",
+	\version:			"1.92",
 	\schelp:			"OpenBCI",
 	\author: 			"Fredrik Olofsson & Krisztian Hofstadter",
 	\country: 			"Germany & UK",


### PR DESCRIPTION
sampleRate must be an integer else filter settings won't be found. broke filter when used together with PlaybackData.